### PR TITLE
No longer need of ? operation for SchedulerBinding.instance

### DIFF
--- a/lib/helpers/size_widget.dart
+++ b/lib/helpers/size_widget.dart
@@ -29,11 +29,11 @@ class _SizeWidgetRenderObject extends RenderProxyBox {
     final size = child?.size;
     if (size == null) return;
 
-    if (SchedulerBinding.instance?.schedulerPhase !=
+    if (SchedulerBinding.instance.schedulerPhase !=
         SchedulerPhase.persistentCallbacks) {
       onSize(size);
     } else {
-      SchedulerBinding.instance?.addPostFrameCallback((_) => onSize(size));
+      SchedulerBinding.instance.addPostFrameCallback((_) => onSize(size));
     }
   }
 }


### PR DESCRIPTION
This is a very old problem which was not fixed in this package.
Since flutter 3.0.0 just made this stable and the latest stable flutter version is 3.3.0 , this issue should be fixed a long time ago.